### PR TITLE
[Step4] 수강 신청 시 같은 userId가 동일한 특강을 여러 번 신청할 때 1번만 성공하도록 처리하기

### DIFF
--- a/src/main/kotlin/com/example/hhpluslectureapply/domain/lecture/LectureApplyHistoryRepository.kt
+++ b/src/main/kotlin/com/example/hhpluslectureapply/domain/lecture/LectureApplyHistoryRepository.kt
@@ -4,6 +4,8 @@ import com.example.hhpluslectureapply.domain.lecture.dto.LectureApplyHistoryDto
 import com.example.hhpluslectureapply.infrastructure.lecture.entity.LectureApplyHistory
 
 interface LectureApplyHistoryRepository {
+	fun findByLectureIdAndUserIdWithLock(lectureId: Long, userId: Long): LectureApplyHistory?
+
 	fun findAllByUserId(userId: Long): List<LectureApplyHistory>
 
 	fun findAllByLectureId(lectureId: Long): List<LectureApplyHistory>

--- a/src/main/kotlin/com/example/hhpluslectureapply/domain/lecture/LectureApplyHistoryService.kt
+++ b/src/main/kotlin/com/example/hhpluslectureapply/domain/lecture/LectureApplyHistoryService.kt
@@ -9,6 +9,16 @@ class LectureApplyHistoryService(
 	private val lectureApplyHistoryRepository: LectureApplyHistoryRepository,
 ) {
 	/**
+	 * PESSIMISTIC_WRITE Lock 을 걸고 특정 특강 아이디와 사용자 아이디로 특강 신청 내역 레코드를 조회하는 메서드
+	 */
+	fun getHistoryByLectureIdAndUserIdWithLock(lectureId: Long, userId: Long): LectureApplyHistoryDto? {
+		val lectureApplyHistory = lectureApplyHistoryRepository.findByLectureIdAndUserIdWithLock(lectureId, userId)
+			?: return null
+
+		return LectureApplyHistoryDto.from(lectureApplyHistory)
+	}
+
+	/**
 	 * 사용자 아이디로 특강 신청 내역 목록 조회하는 메서드
 	 */
 	fun getAllHistoriesByUserId(userId: Long): List<LectureApplyHistoryDto> {

--- a/src/main/kotlin/com/example/hhpluslectureapply/infrastructure/lecture/LectureApplyHistoryJpaRepository.kt
+++ b/src/main/kotlin/com/example/hhpluslectureapply/infrastructure/lecture/LectureApplyHistoryJpaRepository.kt
@@ -2,12 +2,19 @@ package com.example.hhpluslectureapply.infrastructure.lecture
 
 import com.example.hhpluslectureapply.infrastructure.lecture.entity.LectureApplyHistory
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import javax.persistence.LockModeType
 
 interface LectureApplyHistoryJpaRepository : JpaRepository<LectureApplyHistory, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT lah FROM LectureApplyHistory lah WHERE lah.lectureId = :lectureId AND lah.userId = :userId")
+	fun findByLectureIdAndUserIdWithLock(@Param("lectureId") lectureId: Long, @Param("userId") userId: Long): LectureApplyHistory?
+
 	fun findAllByUserId(userId: Long): List<LectureApplyHistory>
 
-	fun findAllByLectureId(@Param("lectureId") lectureId: Long): List<LectureApplyHistory>
+	fun findAllByLectureId(lectureId: Long): List<LectureApplyHistory>
 
 	fun countByLectureId(lectureId: Long): Int
 }

--- a/src/main/kotlin/com/example/hhpluslectureapply/infrastructure/lecture/LectureApplyHistoryRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/hhpluslectureapply/infrastructure/lecture/LectureApplyHistoryRepositoryImpl.kt
@@ -9,6 +9,10 @@ import org.springframework.stereotype.Repository
 class LectureApplyHistoryRepositoryImpl(
 	private val jpaRepository: LectureApplyHistoryJpaRepository
 ) : LectureApplyHistoryRepository {
+	override fun findByLectureIdAndUserIdWithLock(lectureId: Long, userId: Long): LectureApplyHistory? {
+		return jpaRepository.findByLectureIdAndUserIdWithLock(lectureId, userId)
+	}
+
 	override fun findAllByUserId(userId: Long): List<LectureApplyHistory> {
 		return jpaRepository.findAllByUserId(userId)
 	}

--- a/src/main/kotlin/com/example/hhpluslectureapply/usecase/lecture/LectureFacade.kt
+++ b/src/main/kotlin/com/example/hhpluslectureapply/usecase/lecture/LectureFacade.kt
@@ -31,6 +31,12 @@ class LectureFacade(
 			throw LectureException("특강 아이디가 ${lectureId}에 해당하는 특강은 신청 정원이 마감되었습니다.")
 		}
 
+		val lectureApplyHistory = lectureApplyHistoryService.getHistoryByLectureIdAndUserIdWithLock(lectureId, userId)
+		if (lectureApplyHistory != null) {
+			throw LectureException("사용자 ${userId}는 이미 해당 아이디인 ${lectureId} 특강을 신청했습니다.")
+		}
+
+
 		lectureOptionService.updateIncreaseLectureCurrentApplicants(lectureId)
 		lectureApplyHistoryService.insertOrUpdate(LectureApplyHistoryDto.from(lectureApplyInfo))
 	}


### PR DESCRIPTION
### 작업사항
- 수강 신청 요청 메서드에 같은 userId가 동일한 특강을 신청하는 것에 대한 조건 추가
    - 수강 신청 성공 내역인 **LectureApplyHistory** 에서 lectureId, userId로 한 레코드를 조회할 때 `PESSIMISTIC_WRITE` 락을 걸어 조회해온다.
        - `findByLectureIdAndUserIdWithLock()`
    - 해당 LectureApplyHistory 레코드 값이 존재하면 해당 userId가 해당 lectureId에 대한 특강을 이미 신청한 것으로 간주, 해당 레코드 값이 존재하면 수강 신청 실패 처리한다.
- 해당 조건에 대한 병렬 수행 통합 테스트
    - `CountDownLatch`를 이용해 동시에 5번의 수강 신청을 요청, userId와 lectureId는 동일하게 요청
    - 모든 병렬 작업 완료 후, 저장된 신청 성공 내역이 1건만 존재하는지, 그리고 5번의 병렬 요청 중 성공한 건이 1건인지 검증하는 테스트를 작성한다.

### Issue
* #6 
